### PR TITLE
ExceptionMapper on Seed's ValidationException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,14 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- TESTS-->
+        <dependency>
             <groupId>org.seedstack.seed</groupId>
             <artifactId>seed-testing</artifactId>
             <version>${seed.version}</version>
@@ -92,6 +100,12 @@
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
             <version>${javax-el.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>2.22.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/seedstack/validation/ValidationException.java
+++ b/src/main/java/org/seedstack/validation/ValidationException.java
@@ -19,7 +19,7 @@ import org.seedstack.seed.SeedException;
 public class ValidationException extends SeedException {
     private static final long serialVersionUID = 1L;
 
-	protected ValidationException(ErrorCode errorCode) {
+	public ValidationException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 }

--- a/src/main/java/org/seedstack/validation/internal/ValidationExceptionMapper.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationExceptionMapper.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+    package org.seedstack.validation.internal;
+
+import org.seedstack.validation.ValidationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+
+    @Override
+    public Response toResponse(ValidationException exception) {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+}

--- a/src/main/java/org/seedstack/validation/internal/ValidationPlugin.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationPlugin.java
@@ -30,13 +30,10 @@ public class ValidationPlugin extends AbstractPlugin {
 
     @Override
     public Object nativeUnitModule() {
-
         if (validationModule == null) {
             factory = Validation.buildDefaultValidatorFactory();
-
             validationModule = new ValidationModule(factory, validationService);
         }
-
         return validationModule;
     }
 
@@ -51,10 +48,8 @@ public class ValidationPlugin extends AbstractPlugin {
 
     @Override
     public void stop() {
-
         if (factory != null) {
             factory.close();
         }
-
     }
 }

--- a/src/test/java/org/seedstack/validation/internal/ValidationExceptionMapperTest.java
+++ b/src/test/java/org/seedstack/validation/internal/ValidationExceptionMapperTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.validation.internal;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.seedstack.validation.ValidationException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+public class ValidationExceptionMapperTest {
+
+    @Test
+    public void testIsProvider() {
+        ValidationExceptionMapper.class.isAnnotationPresent(Provider.class);
+    }
+
+    @Test
+    public void testReturnError400() {
+        Response response = new ValidationExceptionMapper()
+                .toResponse(new ValidationException(ValidationErrorCode.VALIDATION_ISSUE));
+        Assertions.assertThat(response.getStatus()).isEqualTo(400);
+    }
+}


### PR DESCRIPTION
Add an `ExceptionMapper` on `ValidationException` it will be automatically activated when JAX-RS is enabled.

The `ExceptionMapper` just returns a error 400.
