### PR TITLE
Use standard exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Version 2.2.0 (2016-01-28)
 
-* [new] An ExceptionMapper for ValidationException is provided by default.
+* [new] An `ExceptionMapper` for `ConstraintViolationException` is provided by default.
+* [new] The `ValidatorFactory` is now injectable.
+* [brk] The `ValidationService` is deprecated.
+* [brk] The `org.seedstack.validation.ValidationException` is replaced by the standard `ConstraintViolationException`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Version 2.2.0 (2016-01-28)
+
+* [new] An ExceptionMapper for ValidationException is provided by default.
+

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.seedstack.addons.validation</groupId>
     <artifactId>validation</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <properties>
         <seed.version>2.1.0</seed.version>

--- a/src/it/java/org/seedstack/validation/internal/FieldValidationKoIT.java
+++ b/src/it/java/org/seedstack/validation/internal/FieldValidationKoIT.java
@@ -7,12 +7,12 @@
  */
 package org.seedstack.validation.internal;
 
-import org.seedstack.validation.ValidationException;
-import org.seedstack.validation.internal.pojo.DummyServiceFieldValidation;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.seedstack.seed.it.SeedITRunner;
 import org.seedstack.seed.it.Expect;
+import org.seedstack.seed.it.SeedITRunner;
+import org.seedstack.validation.ValidationException;
+import org.seedstack.validation.internal.pojo.FieldValidationKO;
 
 import javax.inject.Inject;
 
@@ -20,10 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SeedITRunner.class)
 @Expect(value = ValidationException.class, step = Expect.TestingStep.INSTANTIATION)
-public class ValidationPlugin_ValidationErrorIT {
+public class FieldValidationKoIT {
 
     @Inject
-    DummyServiceFieldValidation serviceField;
+    FieldValidationKO serviceField;
 
     @Test
     public void trigger() {

--- a/src/it/java/org/seedstack/validation/internal/FieldValidationOkIT.java
+++ b/src/it/java/org/seedstack/validation/internal/FieldValidationOkIT.java
@@ -7,7 +7,7 @@
  */
 package org.seedstack.validation.internal;
 
-import org.seedstack.validation.internal.pojo.DummyServiceFieldValidationOK;
+import org.seedstack.validation.internal.pojo.FieldValidationOK;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,10 +16,10 @@ import org.seedstack.seed.it.SeedITRunner;
 import javax.inject.Inject;
 
 @RunWith(SeedITRunner.class)
-public class ValidationPlugin_ValidationOkIT {
+public class FieldValidationOkIT {
 
     @Inject
-    DummyServiceFieldValidationOK serviceField;
+    FieldValidationOK serviceField;
 
     @Test
     public void trigger() {

--- a/src/it/java/org/seedstack/validation/internal/InjectionsIT.java
+++ b/src/it/java/org/seedstack/validation/internal/InjectionsIT.java
@@ -7,26 +7,31 @@
  */
 package org.seedstack.validation.internal;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.seedstack.seed.it.Expect;
 import org.seedstack.seed.it.SeedITRunner;
-import org.seedstack.validation.internal.pojo.FieldValidationKO;
 
 import javax.inject.Inject;
-import javax.validation.ConstraintViolationException;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 
 @RunWith(SeedITRunner.class)
-@Expect(value = ConstraintViolationException.class, step = Expect.TestingStep.INSTANTIATION)
-public class FieldValidationKoIT {
+public class InjectionsIT {
 
     @Inject
-    FieldValidationKO serviceField;
+    private ValidatorFactory validatorFactory;
+
+    @Inject
+    private Validator validator;
 
     @Test
-    public void trigger() {
-        assertThat(serviceField).isNull();
+    public void isValidatorFactoryInjectable() {
+        Assertions.assertThat(validatorFactory).isNotNull();
+    }
+
+    @Test
+    public void isValidatorInjectable() {
+        Assertions.assertThat(validator).isNotNull();
     }
 }

--- a/src/it/java/org/seedstack/validation/internal/ValidationPluginIT.java
+++ b/src/it/java/org/seedstack/validation/internal/ValidationPluginIT.java
@@ -7,7 +7,6 @@
  */
 package org.seedstack.validation.internal;
 
-import org.seedstack.validation.ValidationException;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +14,7 @@ import org.seedstack.seed.it.SeedITRunner;
 import org.seedstack.validation.internal.pojo.*;
 
 import javax.inject.Inject;
+import javax.validation.ConstraintViolationException;
 
 @RunWith(SeedITRunner.class)
 public class ValidationPluginIT {
@@ -44,7 +44,7 @@ public class ValidationPluginIT {
         serviceParam.validateNotNullParam("");
     }
 
-    @Test(expected = ValidationException.class)
+    @Test(expected = ConstraintViolationException.class)
     public void param_not_null_validations_are_well_intercepted() {
         serviceParam.validateNotNullParam(null);
     }
@@ -55,7 +55,7 @@ public class ValidationPluginIT {
     }
 
 
-    @Test(expected = ValidationException.class)
+    @Test(expected = ConstraintViolationException.class)
     public void param_valid_validations_are_well_intercepted() {
         serviceParam.validateValidParam(new Pojo(Pojo.State.INVALID));
     }
@@ -65,7 +65,7 @@ public class ValidationPluginIT {
         serviceReturnType.validateNotNullReturn("");
     }
 
-    @Test(expected = ValidationException.class)
+    @Test(expected = ConstraintViolationException.class)
     public void not_null_return_validations_are_well_intercepted() {
         serviceReturnType.validateNotNullReturn(null);
     }
@@ -75,7 +75,7 @@ public class ValidationPluginIT {
         serviceReturnType.validateValidReturn(Pojo.State.VALID);
     }
 
-    @Test(expected = ValidationException.class)
+    @Test(expected = ConstraintViolationException.class)
     public void valid_return_validations_are_well_intercepted() {
         serviceReturnType.validateValidReturn(Pojo.State.INVALID);
     }

--- a/src/it/java/org/seedstack/validation/internal/ValidationPluginIT.java
+++ b/src/it/java/org/seedstack/validation/internal/ValidationPluginIT.java
@@ -20,16 +20,16 @@ import javax.inject.Inject;
 public class ValidationPluginIT {
 
     @Inject
-    DummyServiceParamValidation serviceParam;
+    ParamValidation serviceParam;
 
     @Inject
-    DummyServiceFieldValidationOK serviceField;
+    FieldValidationOK serviceField;
 
     @Inject
-    DummyServiceParamReturnType serviceReturnType;
+    ParamReturnType serviceReturnType;
 
     @Inject
-    DummyServiceWithoutValidation serviceWithoutValidation;
+    WithoutValidation serviceWithoutValidation;
 
     @Test
     public void services_are_well_injected() {

--- a/src/it/java/org/seedstack/validation/internal/ValidationServiceIT.java
+++ b/src/it/java/org/seedstack/validation/internal/ValidationServiceIT.java
@@ -11,16 +11,13 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.seedstack.seed.it.SeedITRunner;
-import org.seedstack.validation.ValidationException;
-import org.seedstack.validation.ValidationService;
 import org.seedstack.validation.internal.pojo.Bean;
 import org.seedstack.validation.internal.pojo.MyImpl;
 import org.seedstack.validation.internal.pojo.Pojo;
 import org.seedstack.validation.internal.pojo.PojoWithDeepValidation;
 
 import javax.inject.Inject;
-import javax.validation.ConstraintViolation;
-import java.util.Set;
+import javax.validation.ConstraintViolationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,16 +36,10 @@ public class ValidationServiceIT {
     public void throwsExceptionOnInvalidPojo() {
         try {
             validationService.staticallyHandle(new Pojo(Pojo.State.INVALID));
-            Assertions.failBecauseExceptionWasNotThrown(ValidationException.class);
-        } catch (ValidationException validationException) {
-            expectViolations(validationException, 3);
+            Assertions.failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
+        } catch (ConstraintViolationException exception) {
+            assertThat(exception.getConstraintViolations()).hasSize(3);
         }
-    }
-
-    private void expectViolations(ValidationException validationException, int expected) {
-        Set<ConstraintViolation<?>> constraintViolations = validationException
-                .get(ValidationService.JAVAX_VALIDATION_CONSTRAINT_VIOLATIONS);
-        assertThat(constraintViolations).hasSize(expected);
     }
 
     @Test
@@ -60,9 +51,9 @@ public class ValidationServiceIT {
     public void throwsExceptionOnDeepValidation() {
         try {
             validationService.staticallyHandle(new PojoWithDeepValidation());
-            Assertions.failBecauseExceptionWasNotThrown(ValidationException.class);
-        } catch (ValidationException validationException) {
-            expectViolations(validationException, 4);
+            Assertions.failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
+        } catch (ConstraintViolationException exception) {
+            assertThat(exception.getConstraintViolations()).hasSize(4);
         }
     }
 
@@ -70,9 +61,9 @@ public class ValidationServiceIT {
     public void validationShouldWorkOnInterface() {
         try {
             validationService.staticallyHandle(new MyImpl());
-            Assertions.failBecauseExceptionWasNotThrown(ValidationException.class);
-        } catch (ValidationException validationException) {
-            expectViolations(validationException, 1);
+            Assertions.failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
+        } catch (ConstraintViolationException exception) {
+            assertThat(exception.getConstraintViolations()).hasSize(1);
         }
     }
 
@@ -82,9 +73,9 @@ public class ValidationServiceIT {
             Bean candidate = new Bean();
             candidate.setHour(25);
             validationService.staticallyHandle(candidate);
-            Assertions.failBecauseExceptionWasNotThrown(ValidationException.class);
-        } catch (ValidationException validationException) {
-            expectViolations(validationException, 1);
+            Assertions.failBecauseExceptionWasNotThrown(ConstraintViolationException.class);
+        } catch (ConstraintViolationException exception) {
+            assertThat(exception.getConstraintViolations()).hasSize(1);
         }
     }
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/Bean.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/Bean.java
@@ -7,19 +7,18 @@
  */
 package org.seedstack.validation.internal.pojo;
 
-import org.seedstack.seed.it.ITBind;
+import javax.validation.constraints.Max;
 
-import javax.validation.constraints.NotNull;
+public class Bean {
 
+    private int hour;
 
+    @Max(24)
+    public int getHour() {
+        return hour;
+    }
 
-@ITBind
-public class DummyServiceFieldValidationOK {
-
-    @NotNull
-    private Object param = new Object();
-
-    public void doSomethingAwesome(Object param) {
-        this.param = param;
+    public void setHour(int hour) {
+        this.hour = hour;
     }
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/FieldValidationKO.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/FieldValidationKO.java
@@ -9,17 +9,16 @@ package org.seedstack.validation.internal.pojo;
 
 import org.seedstack.seed.it.ITBind;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 
-
 @ITBind
-public class DummyServiceParamValidation {
+public class FieldValidationKO {
 
-    public void validateNotNullParam(@NotNull Object param) {
-    }
+    @NotNull
+    private Object param;
 
-    public void validateValidParam(@Valid Pojo param) {
+    public void doSomethingAwesome(Object param) {
+        this.param = param;
     }
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/FieldValidationOK.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/FieldValidationOK.java
@@ -7,14 +7,18 @@
  */
 package org.seedstack.validation.internal.pojo;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Null;
+import org.seedstack.seed.it.ITBind;
 
-public class PojoWithDeepValidation {
+import javax.validation.constraints.NotNull;
 
-    @Null
-    String str = "should be null";
 
-    @Valid
-    private Pojo pojo = new Pojo(Pojo.State.INVALID);
+@ITBind
+public class FieldValidationOK {
+
+    @NotNull
+    private Object param = new Object();
+
+    public void doSomethingAwesome(Object param) {
+        this.param = param;
+    }
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/MyImpl.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/MyImpl.java
@@ -7,18 +7,17 @@
  */
 package org.seedstack.validation.internal.pojo;
 
-import org.seedstack.seed.it.ITBind;
+public class MyImpl implements MyInterface {
 
-import javax.validation.constraints.NotNull;
+    private int color;
 
+    @Override
+    public int getColor() {
+        return color;
+    }
 
-@ITBind
-public class DummyServiceFieldValidation {
-
-    @NotNull
-    private Object param;
-
-    public void doSomethingAwesome(Object param) {
-        this.param = param;
+    @Override
+    public void setColor(int color) {
+        this.color = color;
     }
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/MyInterface.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/MyInterface.java
@@ -7,14 +7,12 @@
  */
 package org.seedstack.validation.internal.pojo;
 
-import javax.validation.Valid;
-import javax.validation.constraints.Null;
+import javax.validation.constraints.Min;
 
-public class PojoWithDeepValidation {
+public interface MyInterface {
 
-    @Null
-    String str = "should be null";
+    @Min(1)
+    int getColor();
 
-    @Valid
-    private Pojo pojo = new Pojo(Pojo.State.INVALID);
+    void setColor(int color);
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/ParamReturnType.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/ParamReturnType.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotNull;
 
 
 @ITBind
-public class DummyServiceParamReturnType {
+public class ParamReturnType {
 
     @NotNull
     public Object validateNotNullReturn(Object param) {

--- a/src/it/java/org/seedstack/validation/internal/pojo/ParamValidation.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/ParamValidation.java
@@ -7,14 +7,18 @@
  */
 package org.seedstack.validation.internal.pojo;
 
+import org.seedstack.seed.it.ITBind;
+
 import javax.validation.Valid;
-import javax.validation.constraints.Null;
+import javax.validation.constraints.NotNull;
 
-public class PojoWithDeepValidation {
 
-    @Null
-    String str = "should be null";
+@ITBind
+public class ParamValidation {
 
-    @Valid
-    private Pojo pojo = new Pojo(Pojo.State.INVALID);
+    public void validateNotNullParam(@NotNull Object param) {
+    }
+
+    public void validateValidParam(@Valid Pojo param) {
+    }
 }

--- a/src/it/java/org/seedstack/validation/internal/pojo/Pojo.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/Pojo.java
@@ -11,10 +11,6 @@ import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Size;
 
-/**
- * @author pierre.thirouin@ext.mpsa.com
- *         14/10/2014
- */
 public class Pojo {
 
     @Size(min = 5)
@@ -26,22 +22,29 @@ public class Pojo {
     @AssertFalse
     private boolean dead = true;
 
-    public static enum State {
+    public enum State {
         VALID,
         INVALID
     }
 
-
     public Pojo(State state) {
         if (State.INVALID.equals(state)) {
-            name = "yoda";
-            age = 10000;
-            dead = true;
+            createInvalidPojo();
         } else {
-            name = "yodaa";
-            age = 99;
-            dead = false;
+            createValidPojo();
         }
+    }
+
+    private void createValidPojo() {
+        name = "yodaa";
+        age = 99;
+        dead = false;
+    }
+
+    private void createInvalidPojo() {
+        name = "yoda";
+        age = 10000;
+        dead = true;
     }
 
     public String getName() {

--- a/src/it/java/org/seedstack/validation/internal/pojo/WithoutValidation.java
+++ b/src/it/java/org/seedstack/validation/internal/pojo/WithoutValidation.java
@@ -11,9 +11,8 @@ package org.seedstack.validation.internal.pojo;
 import org.seedstack.seed.it.ITBind;
 
 @ITBind
-public class DummyServiceWithoutValidation {
+public class WithoutValidation {
 
     public void doSomethingAweswome(Object param) {
-
     }
 }

--- a/src/main/java/org/seedstack/validation/ValidationException.java
+++ b/src/main/java/org/seedstack/validation/ValidationException.java
@@ -15,11 +15,13 @@ import org.seedstack.seed.SeedException;
  * Exception class for validation errors.
  *
  * @author epo.jemba@ext.mpsa.com
+ * @deprecated This exception is no longer used and will be removed in the next version.
+ * Use the standard {@link javax.validation.ConstraintViolationException} instead.
  */
+@Deprecated
 public class ValidationException extends SeedException {
-    private static final long serialVersionUID = 1L;
 
-	public ValidationException(ErrorCode errorCode) {
-		super(errorCode);
-	}
+    public ValidationException(ErrorCode errorCode) {
+        super(errorCode);
+    }
 }

--- a/src/main/java/org/seedstack/validation/ValidationService.java
+++ b/src/main/java/org/seedstack/validation/ValidationService.java
@@ -15,7 +15,10 @@ import java.lang.reflect.Method;
  * Interface for validation service.
  *
  * @author epo.jemba@ext.mpsa.com
+ * @deprecated ValidationService will be removed in the next version. Use {@link javax.validation.Validator} instead.
+ * It can be directly injected or retrieved through the {@link javax.validation.ValidatorFactory}.
  */
+@Deprecated
 public interface ValidationService {
 
     String JAVAX_VALIDATION_CONSTRAINT_VIOLATIONS = "Set<javax.validation.ConstraintViolation>";

--- a/src/main/java/org/seedstack/validation/ValidationService.java
+++ b/src/main/java/org/seedstack/validation/ValidationService.java
@@ -17,6 +17,7 @@ import java.lang.reflect.Method;
  * @author epo.jemba@ext.mpsa.com
  */
 public interface ValidationService {
+
     String JAVAX_VALIDATION_CONSTRAINT_VIOLATIONS = "Set<javax.validation.ConstraintViolation>";
 
     /**

--- a/src/main/java/org/seedstack/validation/internal/MethodValidationInterceptor.java
+++ b/src/main/java/org/seedstack/validation/internal/MethodValidationInterceptor.java
@@ -9,12 +9,11 @@ package org.seedstack.validation.internal;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.seedstack.validation.ValidationService;
 
-class ValidationMethodInterceptor implements MethodInterceptor {
+class MethodValidationInterceptor implements MethodInterceptor {
     private final ValidationService validationService;
 
-    ValidationMethodInterceptor(ValidationService validationService) {
+    MethodValidationInterceptor(ValidationService validationService) {
         this.validationService = validationService;
     }
 

--- a/src/main/java/org/seedstack/validation/internal/StaticValidationProvisionListener.java
+++ b/src/main/java/org/seedstack/validation/internal/StaticValidationProvisionListener.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.validation.internal;
+
+import com.google.inject.spi.ProvisionListener;
+
+/**
+ * Validates provisioned instances eligible for static validation.
+ */
+class StaticValidationProvisionListener implements ProvisionListener {
+
+    private ValidationService validationService;
+
+    public StaticValidationProvisionListener(ValidationService validationService) {
+        this.validationService = validationService;
+    }
+
+    @Override
+    public <A> void onProvision(ProvisionInvocation<A> provision) {
+        A injectee = provision.provision();
+        validationService.staticallyHandle(injectee);
+    }
+}

--- a/src/main/java/org/seedstack/validation/internal/ValidationErrorCode.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationErrorCode.java
@@ -7,15 +7,8 @@
  */
 package org.seedstack.validation.internal;
 
-
 import org.seedstack.seed.ErrorCode;
 
-/**
- * Enumerates all validation error codes.
- *
- * @author epo.jemba@ext.mpsa.com
- * @author adrien.lauer@mpsa.com
- */
 enum ValidationErrorCode implements ErrorCode {
     VALIDATION_ISSUE,
     DYNAMIC_VALIDATION_IS_NOT_SUPPORTED

--- a/src/main/java/org/seedstack/validation/internal/ValidationExceptionMapper.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationExceptionMapper.java
@@ -7,17 +7,16 @@
  */
 package org.seedstack.validation.internal;
 
-import org.seedstack.validation.ValidationException;
-
+import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
 @Provider
-public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+public class ValidationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
 
     @Override
-    public Response toResponse(ValidationException exception) {
+    public Response toResponse(ConstraintViolationException exception) {
         return Response.status(Response.Status.BAD_REQUEST).build();
     }
 }

--- a/src/main/java/org/seedstack/validation/internal/ValidationExceptionMapper.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationExceptionMapper.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-    package org.seedstack.validation.internal;
+package org.seedstack.validation.internal;
 
 import org.seedstack.validation.ValidationException;
 

--- a/src/main/java/org/seedstack/validation/internal/ValidationMethodInterceptor.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationMethodInterceptor.java
@@ -7,19 +7,11 @@
  */
 package org.seedstack.validation.internal;
 
-
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.seedstack.validation.ValidationService;
 
-import static org.seedstack.seed.core.utils.SeedReflectionUtils.cleanProxy;
-
-
 class ValidationMethodInterceptor implements MethodInterceptor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ValidationMethodInterceptor.class);
     private final ValidationService validationService;
 
     ValidationMethodInterceptor(ValidationService validationService) {
@@ -28,13 +20,7 @@ class ValidationMethodInterceptor implements MethodInterceptor {
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
-
-        try {
-            LOGGER.debug("Validation of {}", cleanProxy(invocation.getClass()));
-            return this.validationService.dynamicallyHandleAndProceed(invocation);
-        } finally {
-            LOGGER.debug("End of validation of {}", cleanProxy(invocation.getClass()));
-        }
+        return this.validationService.dynamicallyHandleAndProceed(invocation);
     }
 
 }

--- a/src/main/java/org/seedstack/validation/internal/ValidationPlugin.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationPlugin.java
@@ -37,15 +37,6 @@ public class ValidationPlugin extends AbstractPlugin {
         return validationModule;
     }
 
-    /**
-     * Get the validation service.
-     *
-     * @return the validation service.
-     */
-    public ValidationService getValidationService() {
-        return validationService;
-    }
-
     @Override
     public void stop() {
         if (factory != null) {

--- a/src/main/java/org/seedstack/validation/internal/ValidationPlugin.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationPlugin.java
@@ -7,7 +7,6 @@
  */
 package org.seedstack.validation.internal;
 
-import org.seedstack.validation.ValidationService;
 import io.nuun.kernel.core.AbstractPlugin;
 
 import javax.validation.Validation;
@@ -21,7 +20,7 @@ import javax.validation.ValidatorFactory;
 public class ValidationPlugin extends AbstractPlugin {
     private ValidationService validationService = new ValidationServiceInternal();
     private ValidationModule validationModule;
-    private ValidatorFactory factory;
+    private ValidatorFactory validatorFactory;
 
     @Override
     public String name() {
@@ -31,16 +30,16 @@ public class ValidationPlugin extends AbstractPlugin {
     @Override
     public Object nativeUnitModule() {
         if (validationModule == null) {
-            factory = Validation.buildDefaultValidatorFactory();
-            validationModule = new ValidationModule(factory, validationService);
+            validatorFactory = Validation.buildDefaultValidatorFactory();
+            validationModule = new ValidationModule(validatorFactory, validationService);
         }
         return validationModule;
     }
 
     @Override
     public void stop() {
-        if (factory != null) {
-            factory.close();
+        if (validatorFactory != null) {
+            validatorFactory.close();
         }
     }
 }

--- a/src/main/java/org/seedstack/validation/internal/ValidationService.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationService.java
@@ -5,8 +5,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.validation.internal.fixtures;
-public interface Groupe1Checks
-{
+package org.seedstack.validation.internal;
+
+/**
+ * Interface for validation service.
+ */
+interface ValidationService extends org.seedstack.validation.ValidationService {
 
 }

--- a/src/main/java/org/seedstack/validation/internal/ValidationServiceInternal.java
+++ b/src/main/java/org/seedstack/validation/internal/ValidationServiceInternal.java
@@ -30,10 +30,7 @@ import java.util.Set;
 
 
 /**
- * Internal validation service. It handles static validation, and by contract validation thanks to Validator and ExecutableValidator.
- *
- * @author epo.jemba@ext.mpsa.com
- * @author pierre.thirouin@ext.mpsa.com
+ * Handles static validation, and "by contract" validation thanks to Validator and ExecutableValidator.
  */
 class ValidationServiceInternal implements ValidationService {
     private static final Logger LOGGER = LoggerFactory.getLogger(ValidationServiceInternal.class);
@@ -46,7 +43,6 @@ class ValidationServiceInternal implements ValidationService {
 
     @Override
     public <T> void staticallyHandle(T candidate) {
-
         Set<ConstraintViolation<T>> constraintViolations = validator.validate(candidate);
 
         if (!constraintViolations.isEmpty()) {
@@ -69,11 +65,11 @@ class ValidationServiceInternal implements ValidationService {
                     exceptionMessage.append(rootBeanClass.getName()).append("\n");
                     first = false;
                 }
-                exceptionMessage.append("\t").append(violation.getPropertyPath()).append(" - ").append(violation.getMessage()).append(", but ").append(violation.getInvalidValue()).append(" was found.\n");
+                exceptionMessage.append("\t").append(violation.getPropertyPath()).append(" - ").append(violation.getMessage())
+                        .append(", but ").append(violation.getInvalidValue()).append(" was found.\n");
 
                 ++i;
             }
-
 
             newException.put("message", exceptionMessage);
             newException.put(JAVAX_VALIDATION_CONSTRAINT_VIOLATIONS, constraintViolations);
@@ -89,7 +85,7 @@ class ValidationServiceInternal implements ValidationService {
             throw SeedException.createNew(ValidationErrorCode.DYNAMIC_VALIDATION_IS_NOT_SUPPORTED);
         }
 
-        // TODO : ajout des groupes
+        // TODO : add groups
         Object this1 = invocation.getThis();
         Method method = invocation.getMethod();
         Object[] arguments = invocation.getArguments();
@@ -132,66 +128,52 @@ class ValidationServiceInternal implements ValidationService {
 
     @Override
     public boolean candidateForStaticValidation(Class<?> candidate) {
-        boolean isCandidate = false;
-
-        // look for fields
         for (Field field : candidate.getDeclaredFields()) {
             for (Annotation annotation : field.getAnnotations()) {
-                if (SeedReflectionUtils.hasAnnotationDeep(annotation.annotationType(), Constraint.class) || Valid.class.equals(annotation.annotationType())) {
-                    // check if the annotation type is itself annotated with
-                    // Constraint making it a constraint
-                    isCandidate = true;
-                    break;
+                if (hasConstraintOrValidAnnotation(annotation)) {
+                    return true;
                 }
             }
-            if (isCandidate) {
-                break;
-            }
         }
-
-        return isCandidate;
+        return false;
     }
 
-    @Override
-    public boolean candidateForDynamicValidation(Method candidate) {
-        boolean isCandidate = false;
-        // Check Parameters
-        for (Annotation[] annotationsForOneParameter : candidate.getParameterAnnotations()) {
-            for (Annotation annotation : annotationsForOneParameter) {
-                if (SeedReflectionUtils.hasAnnotationDeep(annotation.annotationType(), Constraint.class) || Valid.class.equals(annotation.annotationType())) {
-                    // check if the annotation type is itself annotated with Constraint making it a constraint
-                    isCandidate = true;
-                    break;
-                }
-            }
-            if (isCandidate) {
-                break;
-            }
-        }
-
-        // Check returned type
-        if (!isCandidate) {
-            for (Annotation annotation : candidate.getAnnotations()) {
-                if (SeedReflectionUtils.hasAnnotationDeep(annotation.annotationType(), Constraint.class) || Valid.class.equals(annotation.annotationType())) {
-                    isCandidate = true;
-                }
-            }
-        }
-
-        return isCandidate;
-
+    private boolean hasConstraintOrValidAnnotation(Annotation annotation) {
+        return SeedReflectionUtils.hasAnnotationDeep(annotation.annotationType(), Constraint.class) || Valid.class.equals(annotation.annotationType());
     }
 
     @Override
     public boolean candidateForDynamicValidation(Class<?> candidate) {
-        // look for methods
-
         for (Method method : candidate.getDeclaredMethods()) {
             if (candidateForDynamicValidation(method)) {
                 return true;
             }
         }
+        return false;
+    }
 
+    @Override
+    public boolean candidateForDynamicValidation(Method candidate) {
+        return shouldValidateParameters(candidate) || shouldValidateReturnType(candidate);
+    }
+
+    private boolean shouldValidateParameters(Method candidate) {
+        for (Annotation[] annotationsForOneParameter : candidate.getParameterAnnotations()) {
+            for (Annotation annotation : annotationsForOneParameter) {
+                if (hasConstraintOrValidAnnotation(annotation)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean shouldValidateReturnType(Method candidate) {
+        for (Annotation annotation : candidate.getAnnotations()) {
+            if (hasConstraintOrValidAnnotation(annotation)) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/src/main/resources/META-INF/errors/org.seedstack.validation.internal.ValidationErrorCode.properties
+++ b/src/main/resources/META-INF/errors/org.seedstack.validation.internal.ValidationErrorCode.properties
@@ -1,9 +1,0 @@
-#
-# Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
-#
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-#
-
-VALIDATION_ISSUE.message=${message}

--- a/src/test/java/org/seedstack/validation/internal/ValidationExceptionMapperTest.java
+++ b/src/test/java/org/seedstack/validation/internal/ValidationExceptionMapperTest.java
@@ -9,10 +9,12 @@ package org.seedstack.validation.internal;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
-import org.seedstack.validation.ValidationException;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
+import java.util.HashSet;
 
 public class ValidationExceptionMapperTest {
 
@@ -24,7 +26,7 @@ public class ValidationExceptionMapperTest {
     @Test
     public void testReturnError400() {
         Response response = new ValidationExceptionMapper()
-                .toResponse(new ValidationException(ValidationErrorCode.VALIDATION_ISSUE));
+                .toResponse(new ConstraintViolationException("error message", new HashSet<ConstraintViolation<?>>()));
         Assertions.assertThat(response.getStatus()).isEqualTo(400);
     }
 }

--- a/src/test/java/org/seedstack/validation/internal/ValidationServiceTest.java
+++ b/src/test/java/org/seedstack/validation/internal/ValidationServiceTest.java
@@ -11,45 +11,38 @@ package org.seedstack.validation.internal;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
-
-import org.seedstack.validation.ValidationService;
-import org.seedstack.validation.internal.fixtures.BeanAll;
-import org.seedstack.validation.internal.fixtures.BeanField;
-import org.seedstack.validation.internal.fixtures.BeanMethodParam;
-import org.seedstack.validation.internal.fixtures.BeanMethodReturnType;
-import org.seedstack.validation.internal.fixtures.BeanNominal;
+import org.seedstack.validation.internal.fixtures.*;
 
 public class ValidationServiceTest {
-	
-	private ValidationService underTest;
 
-	@Before
-	public void init ()
-	{
-		underTest = new ValidationServiceInternal();
-	}
-	
-	@Test
-	public void validationservice_should_check_object_is_candidate_for_static_validation() {
-		Assertions.assertThat ( underTest.candidateForStaticValidation ( BeanField.class)).isTrue();
-		Assertions.assertThat ( underTest.candidateForStaticValidation ( BeanAll.class)).isTrue();
-	}
-	
-	@Test
-	public void validationservice_should_check_object_is_candidate_for_dynamic_validation() {
-		Assertions.assertThat ( underTest.candidateForDynamicValidation ( BeanMethodParam.class)).isTrue();
-		Assertions.assertThat ( underTest.candidateForDynamicValidation ( BeanMethodReturnType.class)).isTrue();
-		Assertions.assertThat ( underTest.candidateForDynamicValidation ( BeanAll.class)).isTrue();
-	}
-	
-	@Test
-	public void validationservice_should_check_object_is_not_candidate_for_static_validation() {
-		Assertions.assertThat ( underTest.candidateForStaticValidation ( BeanNominal.class)).isFalse();
-	}
-	
-	@Test
-	public void validationservice_should_check_object_is_not_candidate_for_dynamic_validation() {
-		Assertions.assertThat ( underTest.candidateForDynamicValidation ( BeanNominal.class)).isFalse();
-	}
+    private ValidationService underTest;
+
+    @Before
+    public void init() {
+        underTest = new ValidationServiceInternal();
+    }
+
+    @Test
+    public void isCandidateForStaticValidation() {
+        Assertions.assertThat(underTest.candidateForStaticValidation(BeanField.class)).isTrue();
+        Assertions.assertThat(underTest.candidateForStaticValidation(BeanAll.class)).isTrue();
+    }
+
+    @Test
+    public void isNotCandidateForStaticValidation() {
+        Assertions.assertThat(underTest.candidateForStaticValidation(BeanNominal.class)).isFalse();
+    }
+
+    @Test
+    public void isCandidateForDynamicValidation() {
+        Assertions.assertThat(underTest.candidateForDynamicValidation(BeanMethodParam.class)).isTrue();
+        Assertions.assertThat(underTest.candidateForDynamicValidation(BeanMethodReturnType.class)).isTrue();
+        Assertions.assertThat(underTest.candidateForDynamicValidation(BeanAll.class)).isTrue();
+    }
+
+    @Test
+    public void isNotCandidateForDynamicValidation() {
+        Assertions.assertThat(underTest.candidateForDynamicValidation(BeanNominal.class)).isFalse();
+    }
 
 }

--- a/src/test/java/org/seedstack/validation/internal/fixtures/BeanAll.java
+++ b/src/test/java/org/seedstack/validation/internal/fixtures/BeanAll.java
@@ -7,83 +7,65 @@
  */
 package org.seedstack.validation.internal.fixtures;
 
+import org.hibernate.validator.constraints.Range;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.hibernate.validator.constraints.Range;
-
 public class BeanAll {
     private int age;
-    
+
     private Long longNumber;
-    
+
     private String name;
-    
+
     private String firstName;
 
     @NotNull(message = "Description obligatoire")
     @Size(min = 1, max = 10)
     private String description;
-    
 
-    public int getAge()
-    {
+    public int getAge() {
         return age;
     }
 
-    public void setAge(@Range(min = 0, max = 200) int age)
-    {
+    public void setAge(@Range(min = 0, max = 200) int age) {
         this.age = age;
     }
 
-    public String getName()
-    {
+    public String getName() {
         return name;
     }
 
-    public void setName(
-    		@NotNull(message = "Nom obligatoire")  @Size(min = 1, max = 10) // 
-    		String name
-    		)
-    {
+    public void setName(@NotNull(message = "Nom obligatoire") @Size(min = 1, max = 10) String name) {
         this.name = name;
     }
 
-    public String getFirstName()
-    {
+    public String getFirstName() {
         return firstName;
     }
 
-    public void setFirstName ( 
-    		@NotNull(groups = { Groupe1Checks.class }
-    		)
-    		String firstName )
-    {
+    public void setFirstName(@NotNull(groups = {Group1Checks.class}) String firstName) {
         this.firstName = firstName;
     }
 
-    public Long getLongNumber()
-    {
+    public Long getLongNumber() {
         return longNumber;
     }
 
-    public void setLongNumber(
-    		@NotNull @Min(value = 10L) @Max(value = 999999999999999999L)
-    		Long longNumber)
-    {
+    public void setLongNumber(@NotNull @Min(value = 10L) @Max(value = 999999999999999999L) Long longNumber) {
         this.longNumber = longNumber;
     }
 
-	public String getDescription() {
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 
-	public void setDescription(String description) {
-		this.description = description;
-	}
-	
-	
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
 
 }

--- a/src/test/java/org/seedstack/validation/internal/fixtures/BeanField.java
+++ b/src/test/java/org/seedstack/validation/internal/fixtures/BeanField.java
@@ -7,68 +7,59 @@
  */
 package org.seedstack.validation.internal.fixtures;
 
+import org.hibernate.validator.constraints.Range;
+
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.hibernate.validator.constraints.Range;
-
 public class BeanField {
-	    @Range(min = 0, max = 200)
-	    private int age;
+    @Range(min = 0, max = 200)
+    private int age;
 
-	    @NotNull
-	    @Range(min = 10L, max = 999999999999999999L)
-	    private Long longNumber;
+    @NotNull
+    @Range(min = 10L, max = 999999999999999999L)
+    private Long longNumber;
 
-	    @NotNull(message = "Nom obligatoire")
-	    @Size(min = 1, max = 10)
-	    private String name;
+    @NotNull(message = "Nom obligatoire")
+    @Size(min = 1, max = 10)
+    private String name;
 
-	    @NotNull(groups = { Groupe1Checks.class })
-	    private String firstName;
-	    
-	    public BeanField()
-	    {
-	    }
+    @NotNull(groups = {Group1Checks.class})
+    private String firstName;
 
-	    public int getAge()
-	    {
-	        return age;
-	    }
+    public BeanField() {
+    }
 
-	    public void setAge(int age)
-	    {
-	        this.age = age;
-	    }
+    public int getAge() {
+        return age;
+    }
 
-	    public String getName()
-	    {
-	        return name;
-	    }
+    public void setAge(int age) {
+        this.age = age;
+    }
 
-	    public void setName(String name)
-	    {
-	        this.name = name;
-	    }
+    public String getName() {
+        return name;
+    }
 
-	    public String getFirstName()
-	    {
-	        return firstName;
-	    }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	    public void setFirstName(String firstName)
-	    {
-	        this.firstName = firstName;
-	    }
+    public String getFirstName() {
+        return firstName;
+    }
 
-	    public Long getLongNumber()
-	    {
-	        return longNumber;
-	    }
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
 
-	    public void setLongNumber(Long longNumber)
-	    {
-	        this.longNumber = longNumber;
-	    }
+    public Long getLongNumber() {
+        return longNumber;
+    }
+
+    public void setLongNumber(Long longNumber) {
+        this.longNumber = longNumber;
+    }
 
 }

--- a/src/test/java/org/seedstack/validation/internal/fixtures/BeanMethodParam.java
+++ b/src/test/java/org/seedstack/validation/internal/fixtures/BeanMethodParam.java
@@ -7,71 +7,56 @@
  */
 package org.seedstack.validation.internal.fixtures;
 
+import org.hibernate.validator.constraints.Range;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.hibernate.validator.constraints.Range;
-
 public class BeanMethodParam {
     private int age;
-    
-    private Long longNumber;
-    
-    private String name;
-    
-    private String firstName;
-    
 
-    public int getAge()
-    {
+    private Long longNumber;
+
+    private String name;
+
+    private String firstName;
+
+
+    public int getAge() {
         return age;
     }
 
-    public void setAge(@Range(min = 0, max = 200) int age)
-    {
+    public void setAge(@Range(min = 0, max = 200) int age) {
         this.age = age;
     }
 
-    public String getName()
-    {
+    public String getName() {
         return name;
     }
 
-    public void setName(
-    		@NotNull(message = "Nom obligatoire")  @Size(min = 1, max = 10) // 
-    		String name
-    		)
-    {
+    public void setName(@NotNull(message = "Nom obligatoire") @Size(min = 1, max = 10) String name) {
         this.name = name;
     }
 
-    public String getFirstName()
-    {
+    public String getFirstName() {
         return firstName;
     }
 
-    public void setFirstName ( 
-    		@NotNull(groups = { Groupe1Checks.class }
-    		)
-    		String firstName )
-    {
+    public void setFirstName(@NotNull(groups = {Group1Checks.class}) String firstName) {
         this.firstName = firstName;
     }
 
-    public Long getLongNumber()
-    {
+    public Long getLongNumber() {
         return longNumber;
     }
 
     public void setLongNumber(
-    		@NotNull @Min(value = 10L) @Max(value = 999999999999999999L)
-    		Long longNumber)
-    {
+            @NotNull @Min(value = 10L) @Max(value = 999999999999999999L)
+            Long longNumber) {
         this.longNumber = longNumber;
     }
-	
-	
+
 
 }

--- a/src/test/java/org/seedstack/validation/internal/fixtures/BeanMethodReturnType.java
+++ b/src/test/java/org/seedstack/validation/internal/fixtures/BeanMethodReturnType.java
@@ -7,72 +7,60 @@
  */
 package org.seedstack.validation.internal.fixtures;
 
+import org.hibernate.validator.constraints.Range;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
-import org.hibernate.validator.constraints.Range;
-
 public class BeanMethodReturnType {
-	    
 
-	    private int age;
-	    
-	    private Long longNumber;
-	    
-	    private String name;
-	    
-	    private String firstName;
-	    
+    private int age;
 
-	    @Range(min = 0, max = 200)
-	    public int getAge()
-	    {
-	        return age;
-	    }
+    private Long longNumber;
 
-	    public void setAge( int age)
-	    {
-	        this.age = age;
-	    }
+    private String name;
 
-	    @NotNull(message = "Nom obligatoire")  @Size(min = 1, max = 10)
-	    public String getName()
-	    {
-	        return name;
-	    }
+    private String firstName;
 
-	    public void setName(
-	    		 
-	    		String name
-	    		)
-	    {
-	        this.name = name;
-	    }
+    @Range(min = 0, max = 200)
+    public int getAge() {
+        return age;
+    }
 
-	    @NotNull(groups = { Groupe1Checks.class })
-	    public String getFirstName()
-	    {
-	        return firstName;
-	    }
+    public void setAge(int age) {
+        this.age = age;
+    }
 
-	    public void setFirstName ( 
-	    		
-	    		String firstName )
-	    {
-	        this.firstName = firstName;
-	    }
+    @NotNull(message = "Nom obligatoire")
+    @Size(min = 1, max = 10)
+    public String getName() {
+        return name;
+    }
 
-	    @NotNull @Min(value = 10L) @Max(value = 999999999999999999L)
-	    public Long getLongNumber()
-	    {
-	        return longNumber;
-	    }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	    public void setLongNumber( Long longNumber )
-	    {
-	        this.longNumber = longNumber;
-	    }
+    @NotNull(groups = {Group1Checks.class})
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    @NotNull
+    @Min(value = 10L)
+    @Max(value = 999999999999999999L)
+    public Long getLongNumber() {
+        return longNumber;
+    }
+
+    public void setLongNumber(Long longNumber) {
+        this.longNumber = longNumber;
+    }
 
 }

--- a/src/test/java/org/seedstack/validation/internal/fixtures/BeanNominal.java
+++ b/src/test/java/org/seedstack/validation/internal/fixtures/BeanNominal.java
@@ -9,56 +9,47 @@ package org.seedstack.validation.internal.fixtures;
 
 
 public class BeanNominal {
-	    private int age;
+    private int age;
 
-	    private Long longNumber;
+    private Long longNumber;
 
-	    private String name;
+    private String name;
 
-	    private String firstName;
-	    
-	    public BeanNominal()
-	    {
-	    }
+    private String firstName;
 
-	    public int getAge()
-	    {
-	        return age;
-	    }
+    public BeanNominal() {
+    }
 
-	    public void setAge(int age)
-	    {
-	        this.age = age;
-	    }
+    public int getAge() {
+        return age;
+    }
 
-	    public String getName()
-	    {
-	        return name;
-	    }
+    public void setAge(int age) {
+        this.age = age;
+    }
 
-	    public void setName(String name)
-	    {
-	        this.name = name;
-	    }
+    public String getName() {
+        return name;
+    }
 
-	    public String getFirstName()
-	    {
-	        return firstName;
-	    }
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	    public void setFirstName(String firstName)
-	    {
-	        this.firstName = firstName;
-	    }
+    public String getFirstName() {
+        return firstName;
+    }
 
-	    public Long getLongNumber()
-	    {
-	        return longNumber;
-	    }
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
 
-	    public void setLongNumber(Long longNumber)
-	    {
-	        this.longNumber = longNumber;
-	    }
+    public Long getLongNumber() {
+        return longNumber;
+    }
+
+    public void setLongNumber(Long longNumber) {
+        this.longNumber = longNumber;
+    }
 
 }

--- a/src/test/java/org/seedstack/validation/internal/fixtures/Group1Checks.java
+++ b/src/test/java/org/seedstack/validation/internal/fixtures/Group1Checks.java
@@ -5,10 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package org.seedstack.validation.internal;
+package org.seedstack.validation.internal.fixtures;
 
-import org.seedstack.seed.ErrorCode;
-
-enum ValidationErrorCode implements ErrorCode {
-    DYNAMIC_VALIDATION_IS_NOT_SUPPORTED
+public interface Group1Checks {
 }


### PR DESCRIPTION
- Deprecate the Seed's `ValidationException` and replace it by the standard `ConstraintViolationException`.
- The `ValidationService` is also deprecated in order to be hidden internally in the next version.
- The `ValidatorFactory` is now injectable.
- The `Validator` is no more a singleton but use the caching of the `ValidatorFactory`.
